### PR TITLE
Change requirements for pyinstaller, clarify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To run RoAMer you need to have a VirtualBox or KVM environment with a Windows Vi
   * At least Firewall and Windows Defender need to be deactivated in the VM
   * Virtual Network, where the host system is able to communicate with the VM
 * Python (virtual) environment (<= v3.7) that satisfies:
-  * [pyinstaller](https://pypi.org/project/PyInstaller/)
+  * [pyinstaller](https://pypi.org/project/PyInstaller/) (<= v3.6)
   * [pywin32](https://pypi.org/project/pywin32/)
 
 #### Host System
@@ -30,6 +30,7 @@ To run RoAMer you need to have a VirtualBox or KVM environment with a Windows Vi
 ### Deployment
 * run `PeHeaderWhitelister.exe C:\` in Windows CMD in the VM and copy the resulting `pe_header_whitelist.json` file of this script to the current VM's users home directory (`C:\Users\%username%\`)
 * Copy the file `unpacker/dist/main.exe` from the VM to the host system into `$Repository/roamer/bin`
+* Ensure that the receiver `main.exe` is not stored at `C:\Users\%username%\main.exe` (this path is already reserved for the unpacker `main.exe`)
 * start receiver `main.exe` in the VM within a command line terminal (cmd.exe) as an administrator
 * move desktop the symbols so that the upper left corner of your desktop is free
 * create a shortcut to notepad as the first icon directly below the free space (right click -> New -> Shortcut: `C:\Windows\notepad.exe`)


### PR DESCRIPTION
Setting up RoAMer, I encountered two problems:

1) RoAMer does not work correctly when using the newest version of pyinstaller
2) When the receiver `main.exe` is stored at `C:\Users\%username%\main.exe`, the unpacker `main.exe` will not be copied to the guest system, resulting in an error

The updated readme accounts for these possible pitfalls.
