### PR TITLE
Fix missing nullbytes in dumps

### DIFF
--- a/roamer/DumpPersister.py
+++ b/roamer/DumpPersister.py
@@ -76,7 +76,7 @@ def _merge_dump_segments(dump):
         if segment["isdummy"]:
             result += b"\x00" * segment["size"]
         else:
-            result += base64.b64decode(segment["dump"])
+            result += base64.b64decode(segment["dump"]) + b"\x00" * (segment["size"] - segment["dumped_size"])
     return result
 
 

--- a/template.config.py
+++ b/template.config.py
@@ -28,6 +28,7 @@ UNPACKER_CONFIG = {
                 "only_executable_filter",
                 "mapped_memory"
             ],
+            "discard_reserved_segment_size": 0x10000, # set to None to disable discarding of any reserved segments
             "additional_pe_whitelist": {"dotNet1.dll": ["c4aa77a6556cc19a1f1e5f5dd85ef7966489d413c19ea7433d9a4e244ddb4450"],
                                         "dotNet2.dll": ["0bf521a45ff4ad7bb21220a069441a60d48874a61e30659bbb6a65f2d616d2fd"],
                                         "dotNet3.dll": ["5bb85f402bed10719d8fcf5151c7ac9e989ee6b6fed3232283a126dcb79fb633"],

--- a/unpacker/Unpacker.py
+++ b/unpacker/Unpacker.py
@@ -20,7 +20,7 @@ class Unpacker:
             additionalWhitelist = config["additional_pe_whitelist"]
         else:
             additionalWhitelist = {}
-        self.dumper = Dumper(config["dump_filters"], additionalWhitelist)
+        self.dumper = Dumper(config["dump_filters"], additionalWhitelist, config["discard_reserved_segment_size"])
         self.sample = sample
         self.sampleName = ""
         self.config = config


### PR DESCRIPTION
This fix to the `DumpPersister` will pad segments with nullbytes if `dumped_size < size`.

Without this fix, especially dumps of .NET payloads will miss several chunks of 0x1000 nullbytes, corrupting the dump.
