### PR TITLE
Deployer improvements

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -12,10 +12,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='RoAMerDeployer')
     parser.add_argument('Tasks', metavar='Task', type=str, nargs="*", help='Path to sample or folder of samples')
     parser.add_argument('--no-headless', action='store_false', help='Start the Sandbox in headless mode', dest="headless")
+    parser.add_argument('--keep-running', action='store_true', help='Keep Sandbox running after deployment', dest="keep")
+    parser.add_argument('--no-snapshot', action='store_true', help='Do no take a new Snapshot after deployment', dest="no_snap")
     parser.add_argument('--vm', action='store', help='This can be used to force a VM past the config-file', default="")
     parser.add_argument('--snapshot', action='store', help='This can be used to force a snapshot past the config-file', default="")
     parser.add_argument('--config', action='store', help="Which config shall be used?", default="deploy_config")
     parser.add_argument('--ident', action="store", help="Configure an identifier for the output.", default="")
 
     args = parser.parse_args()
-    deployer = ExecuteDeployerTasks(importlib.import_module(args.config), args.Tasks, args.headless, args.vm, args.snapshot, args.ident)
+    deployer = ExecuteDeployerTasks(importlib.import_module(args.config), args.Tasks, args.headless, args.vm, args.snapshot, args.ident, args.keep, args.no_snap)

--- a/updater/updater.py
+++ b/updater/updater.py
@@ -110,6 +110,7 @@ class Updater:
             subprocess.Popen(f"cmd /c {tmp_bat_path}", stdout=None)
 
     def update_whitelist(self, executable_path):
+        self.cleanup([self.userPath+"pe_header_whitelist.json"])
         subprocess.Popen(executable_path+" C:\\", cwd=self.userPath).wait()
 
     def replace_receiver(self, source):
@@ -124,16 +125,24 @@ class Updater:
             content = f_in.read()
         return self._to_base64(content)
 
-    def send_binaries(self):
+    def gather_data_and_send(self):
         logging.info("Send back binaries to Host")
-        result = {
-            "unpacker": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\unpacker\\dist\\main.exe"),
-            "receiver": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\receiver\\dist\\main.exe"),
-            "whitelister": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\whitelister\\dist\\PEHeaderWhitelister.exe"),
-            "update_launcher": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\updater\\dist\\update_launcher.exe"),
-            "updater": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\updater\\dist\\updater.exe"),
-        }
-        self.send_output(result)
+        result = {}
+        if "compile_on_client" in self.tasks:
+            result.update({
+                "unpacker": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\unpacker\\dist\\main.exe"),
+                "receiver": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\receiver\\dist\\main.exe"),
+                "whitelister": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\whitelister\\dist\\PEHeaderWhitelister.exe"),
+                "update_launcher": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\updater\\dist\\update_launcher.exe"),
+                "updater": self._get_content_of_file_as_base64(self.roamerRepoPath+"\\updater\\dist\\updater.exe"),
+            })
+        if "whitelist" in self.tasks:
+            result["pe_header_whitelist.json"] = self._get_content_of_file_as_base64(self.userPath+"pe_header_whitelist.json")
+
+        if len(result) != 0: 
+            self.send_output(result)
+        else:
+            self.send_nothing()
 
     def cleanup(self, list):
         for entry in list:
@@ -180,10 +189,8 @@ class Updater:
         if "whitelist" in self.tasks:
             self.update_whitelist(whitelister_source_path)
 
-        if "compile_on_client" in self.tasks and not self.isLocalUnpacking:
-            self.send_binaries()
-        elif not self.isLocalUnpacking:
-            self.send_nothing()
+        if not self.isLocalUnpacking:
+            self.gather_data_and_send()
 
         if "reinit_and_store" in self.tasks:
             if self.config["requires_cleaning_before_snapshot"]:

--- a/updater/updater.py
+++ b/updater/updater.py
@@ -65,6 +65,8 @@ class Updater:
         self.send_output("empty")
     
     def extract_source(self):
+        logging.info("Remove old repo before extracting source")
+        self.cleanup([self.roamerRepoPath])
         logging.info("Extract source code")
         extract(self.roamerZipPath, self.roamerRepoPath)
 


### PR DESCRIPTION
These commits make the following changes to the deployer:

- Command line flags can be used to prevent the deployer from taking snapshots and/or stopping the VM after deployment. 
- When the deployer is used to update the client's whitelist, the resulting whitelist is send back to the host. This simplifies testing the Whitelister on real data.
- Before the deployer extracts source and compiles binaries on a client, existing source and/or binaries are deleted. This prevents sending back old builds to the host (i.e. silent failure) if the compilation failed.
- For similar reasons, an old whitelist will be deleted before the Whitelister is executed.