### PR TITLE
New filters

### DIFF
--- a/template.config.py
+++ b/template.config.py
@@ -25,6 +25,7 @@ UNPACKER_CONFIG = {
             # Have the unpacker reduce the candidate list of segments to dump based on 
             # these filters.
             "dump_filters": [
+                "own_pid_filter"
                 "pe_header_whitelist",
                 "memmap_change",
                 "only_executable_filter",

--- a/template.config.py
+++ b/template.config.py
@@ -28,6 +28,8 @@ UNPACKER_CONFIG = {
                 "pe_header_whitelist",
                 "memmap_change",
                 "only_executable_filter",
+                #"only_pe_header_filter",
+                #"only_executable_or_pe_header_filter",
                 "mapped_memory"
             ],
             # Control over merging of gapped segments

--- a/unpacker/dumping/dumper.py
+++ b/unpacker/dumping/dumper.py
@@ -6,6 +6,8 @@ from unpacker.dumping.dump_task import DumpTask
 from unpacker.dumping.mapped_memory_filter import MappedMemoryFilter
 from unpacker.dumping.memmap_change_filter import MemMapChangeFilter
 from unpacker.dumping.only_executable_filter import OnlyExecutableFilter
+from unpacker.dumping.only_executable_or_pe_header_filter import OnlyExecutableOrPeHeaderFilter
+from unpacker.dumping.only_pe_header_filter import OnlyPeHeaderFilter
 from unpacker.dumping.whitelist_filter import WhitelistFilter
 from utility import pe_tools
 from unpacker.winwrapper.utilities import return_memory_map_for_pid, open_process, read_memory, close_handle, name_of_process
@@ -33,6 +35,10 @@ class Dumper:
                 filters.append(MappedMemoryFilter(self))
             elif filterName == "only_executable_filter":
                 filters.append(OnlyExecutableFilter(self))
+            elif filterName == "only_executable_or_pe_header_filter":
+                filters.append(OnlyExecutableOrPeHeaderFilter(self))
+            elif filterName == "only_pe_header_filter":
+                filters.append(OnlyPeHeaderFilter(self))
         return filters
 
     def update_filters(self):

--- a/unpacker/dumping/dumper.py
+++ b/unpacker/dumping/dumper.py
@@ -8,6 +8,7 @@ from unpacker.dumping.memmap_change_filter import MemMapChangeFilter
 from unpacker.dumping.only_executable_filter import OnlyExecutableFilter
 from unpacker.dumping.only_executable_or_pe_header_filter import OnlyExecutableOrPeHeaderFilter
 from unpacker.dumping.only_pe_header_filter import OnlyPeHeaderFilter
+from unpacker.dumping.own_pid_filter import OwnPidFilter
 from unpacker.dumping.whitelist_filter import WhitelistFilter
 from utility import pe_tools
 from unpacker.winwrapper.utilities import return_memory_map_for_pid, open_process, read_memory, close_handle, name_of_process
@@ -39,6 +40,8 @@ class Dumper:
                 filters.append(OnlyExecutableOrPeHeaderFilter(self))
             elif filterName == "only_pe_header_filter":
                 filters.append(OnlyPeHeaderFilter(self))
+            elif filterName == "own_pid_filter":
+                filters.append(OwnPidFilter(self))
         return filters
 
     def update_filters(self):

--- a/unpacker/dumping/only_executable_or_pe_header_filter.py
+++ b/unpacker/dumping/only_executable_or_pe_header_filter.py
@@ -1,0 +1,36 @@
+import logging
+
+from utility.pe_tools import checkMzHeaderInDump
+from unpacker.winwrapper.utilities import open_process, read_memory
+
+class OnlyExecutableOrPeHeaderFilter:
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def update(self):
+        pass
+    
+    def _task_contains_pe_header(self, task):
+        process_handle = open_process(task.pid)
+        for segment in task.segments:
+            if not segment.is_dummy:
+                data = read_memory(process_handle, segment.base_addr, segment.size)
+                if checkMzHeaderInDump(data):
+                    return True
+        return False
+
+    def filter(self, tasks):
+        filtered_tasks = []
+        execution_flags = [0x40, 0x10, 0x20, 0x80]
+        for task in tasks:
+            for segment in task.segments:
+                if segment.flags in execution_flags:
+                    filtered_tasks.append(task)
+                    break
+            else:
+                if self._task_contains_pe_header(task):
+                    filtered_tasks.append(task)
+
+        logging.info("removed %d/%d dump tasks by removing non-executable tasks which do not contain a PE header.", len(tasks) - len(filtered_tasks), len(tasks))
+        return filtered_tasks

--- a/unpacker/dumping/only_pe_header_filter.py
+++ b/unpacker/dumping/only_pe_header_filter.py
@@ -1,0 +1,32 @@
+import logging
+
+from utility.pe_tools import checkMzHeaderInDump
+from unpacker.winwrapper.utilities import open_process, read_memory
+
+class OnlyPeHeaderFilter:
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def update(self):
+        pass
+    
+    def _task_contains_pe_header(self, task):
+        process_handle = open_process(task.pid)
+        for segment in task.segments:
+            if not segment.is_dummy:
+                data = read_memory(process_handle, segment.base_addr, segment.size)
+                if checkMzHeaderInDump(data):
+                    return True
+        return False
+
+    def filter(self, tasks):
+        filtered_tasks = []
+        for task in tasks:
+            if self._task_contains_pe_header(task):
+                filtered_tasks.append(task)
+
+        logging.info("removed %d/%d dump tasks by removing tasks which do not contain a PE header.", len(tasks) - len(filtered_tasks), len(tasks))
+        return filtered_tasks
+
+

--- a/unpacker/dumping/own_pid_filter.py
+++ b/unpacker/dumping/own_pid_filter.py
@@ -1,0 +1,20 @@
+import logging
+import os
+
+class OwnPidFilter:
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def update(self):
+        pass
+
+    def filter(self, tasks):
+        filtered_tasks = []
+        own_pid = os.getpid()
+        for task in tasks:
+            if task.pid != own_pid:
+                filtered_tasks.append(task)
+        logging.info("removed %d/%d dump tasks by excluding unpacker pid.", len(tasks) - len(filtered_tasks), len(tasks))
+        return filtered_tasks
+


### PR DESCRIPTION
- The `OnlyPeHeaderFilter` allows dumping only those tasks which contain a `PeHeader`.
It can be used instead of the `OnlyExecutableOrPeHeaderFilter`.

- Additionaly an `OnlyExecutableOrPeHeaderFilter` allows dumping tasks which contain either a PeHeader or an executable memory region.

- The `OwnPidFilter` will exclude the memory of the unpacker itself. Without this filter, e.g. the `OnlyPeHeaderFilter` can match its own memory.

