### PR TITLE
Post processing

### DIFF
--- a/roamer/DumpPersister.py
+++ b/roamer/DumpPersister.py
@@ -45,11 +45,12 @@ def _strip_trailing_zeroes(data):
 def _persist_dump(dump, result_path, config):
     merged_segments = _merge_dump_segments(dump)
     offsets = set()
-    offsets.add(0)
     # Always dump original file
+    offsets.add(0)
     # Add offsets of all contained PE files
-    for offset, _ in iterate_pe_headers(merged_segments):
-        offsets.add(offset)
+    if "pe_carving" in config["post_processing_steps"]:
+        for offset, _ in iterate_pe_headers(merged_segments):
+            offsets.add(offset)
     for offset in offsets:
         dump_name = "%d_0x%08x" % (dump["pid"], dump["base"]+offset)
         dump_path = os.path.join(result_path, dump_name)

--- a/roamer/DumpPersister.py
+++ b/roamer/DumpPersister.py
@@ -43,18 +43,20 @@ def _strip_trailing_zeroes(data):
 
 def _persist_dump(dump, result_path):
     merged_segments = _merge_dump_segments(dump)
-    # dump PEs
+    offsets = set()
+    offsets.add(0)
+    # Always dump original file
+    # Add offsets of all contained PE files
     for offset, _ in iterate_pe_headers(merged_segments):
-        pe_name = "%d_0x%08x_PE" % (dump["pid"], dump["base"]+offset)
-        pe_path = os.path.join(result_path, pe_name)
-        with open(pe_path, "wb") as fPE:
+        offsets.add(offset)
+    for offset in offsets:
+        dump_name = "%d_0x%08x" % (dump["pid"], dump["base"]+offset)
+        dump_path = os.path.join(result_path, dump_name)
+        with open(dump_path, "wb") as fPE:
             fPE.write(_strip_trailing_zeroes(merged_segments[offset:]))
     dump_name = "%d_0x%08x" % (dump["pid"], dump["base"])
-    dump_path = os.path.join(result_path, dump_name)
     dump_info = deepcopy(dump)
     dump_info["dump_name"] = dump_name
-    with open(dump_path, "wb") as fDump:
-        fDump.write(_strip_trailing_zeroes(merged_segments))
     segment_infos = []
     for segment in dump_info["segments"]:
         segment.pop("dump")

--- a/roamer/DumpPersister.py
+++ b/roamer/DumpPersister.py
@@ -72,6 +72,7 @@ def _persist_dumps(config_result, result_path):
     for dump in config_result["dumps"]:
         dump_info = _persist_dump(dump, result_path)
         dump_stats[dump_info["dump_name"]] = dump_info
+        dump_info["process_name"] = str(base64.b64decode(dump_info["process_name"]))
     _persist_as_json(dump_stats, os.path.join(result_path, "dump_stats.json"))
 
 

--- a/roamer/DumpPersister.py
+++ b/roamer/DumpPersister.py
@@ -48,7 +48,8 @@ def _persist_dump(dump, result_path, config):
     # Always dump original file
     offsets.add(0)
     # Add offsets of all contained PE files
-    if "pe_carving" in config["post_processing_steps"]:
+    post_processing_steps = config.get("post_processing_steps", [])
+    if "pe_carving" in post_processing_steps:
         for offset, _ in iterate_pe_headers(merged_segments):
             offsets.add(offset)
     for offset in offsets:
@@ -87,7 +88,8 @@ def _persist_dumps(config_result, result_path, config):
     for dump in config_result["dumps"]:
         dump_info = _persist_dump(dump, result_path, config)
         dump_stats[dump_info["dump_name"]] = dump_info
-        dump_info["process_name"] = _decode_process_name(dump_info["process_name"], config["human_readable_process_names"])
+        process_name_config = config.get("human_readable_process_names", "never")
+        dump_info["process_name"] = _decode_process_name(dump_info["process_name"], process_name_config)
     _persist_as_json(dump_stats, os.path.join(result_path, "dump_stats.json"))
 
 

--- a/roamer/RoAMer.py
+++ b/roamer/RoAMer.py
@@ -16,7 +16,10 @@ class RoAMer:
 
     def __init__(self, roamer_config, headless, vm, snapshot, ident):
         self.unpacker_config = roamer_config.UNPACKER_CONFIG
-        self.post_processing_config = roamer_config.POST_PROCESSING_CONFIG
+        if hasattr(roamer_config, "POST_PROCESSING_CONFIG"):
+            self.post_processing_config = roamer_config.POST_PROCESSING_CONFIG
+        else:
+            self.post_processing_config = {}
         self.bins = roamer_config.BIN_ROOT
         self.vm_name = roamer_config.VM_NAME if not vm else vm
         self.snapshotName = roamer_config.SNAPSHOT_NAME if not snapshot else snapshot

--- a/roamer/RoAMer.py
+++ b/roamer/RoAMer.py
@@ -16,6 +16,7 @@ class RoAMer:
 
     def __init__(self, roamer_config, headless, vm, snapshot, ident):
         self.unpacker_config = roamer_config.UNPACKER_CONFIG
+        self.post_processing_config = roamer_config.POST_PROCESSING_CONFIG
         self.bins = roamer_config.BIN_ROOT
         self.vm_name = roamer_config.VM_NAME if not vm else vm
         self.snapshotName = roamer_config.SNAPSHOT_NAME if not snapshot else snapshot
@@ -138,7 +139,7 @@ class RoAMer:
                     output_path = target_path
                 else:
                     output_path = os.path.join(output_folder, os.path.basename(target_path))
-                persist_data(output_path, json.loads(returned_raw_data), self.ident)
+                persist_data(output_path, json.loads(returned_raw_data), self.ident, self.post_processing_config)
         else:
             LOG.info("Nothing returned by unpacker")
         self.vm_controller.stop_vm(self.vm_name)

--- a/template.config.py
+++ b/template.config.py
@@ -60,6 +60,14 @@ UNPACKER_CONFIG = {
     ]
 }
 
+
+# Configure behaviour of DumpPersister
+POST_PROCESSING_CONFIG = {
+    # possible values: "if_ascii", "escape", "never"
+    "human_readable_process_names": "if_ascii", 
+}
+
+
 # Virtualization related
 ## VM_CONTROLLER: choose "VboxManageController" for VirtualBox or "KvmManageController" for KVM
 VM_CONTROLLER = "VboxManageController"

--- a/template.config.py
+++ b/template.config.py
@@ -65,6 +65,9 @@ UNPACKER_CONFIG = {
 POST_PROCESSING_CONFIG = {
     # possible values: "if_ascii", "escape", "never"
     "human_readable_process_names": "if_ascii", 
+    "post_processing_steps": [
+        "pe_carving",
+    ],
 }
 
 


### PR DESCRIPTION
Add the following configurable post-processing steps:
- Process names can be stored in plain text instead of base64 encoded
- PE carving can be performed on the dumps