### PR TITLE
Roamer queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ config.py
 deploy_config.py
 deployer_results
 data/*
+queue.lock
+clone_configs.py

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -570,9 +570,9 @@ def monitor_ids(connection, ids):
     except KeyboardInterrupt:
         answer = None
         print()
-        while answer not in ["q", "c", "m", "k"]:
-            answer = input("""What do you want to do (a/b/c):
-q) just quit, i.e. stop monitoring
+        while answer not in ["d", "c", "m", "k"]:
+            answer = input("""What do you want to do (d/c/m/k):
+d) detach, i.e. stop monitoring
 c) cancel your unstarted queued jobs and stop monitoring
 m) cancel your unstarted queued jobs and keep monitoring running jobs
 k) cancel and/or kill all of your jobs

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -7,9 +7,9 @@ import json
 import logging
 import os
 from threading import Thread
+from queue import Queue
 import time
 import traceback
-from multiprocessing import Process, Queue
 from multiprocessing.connection import Client, Listener
 
 from roamer.RoAMer import RoAMer
@@ -17,8 +17,6 @@ from roamer.RoAMer import RoAMer
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s %(message)s")
 FORMATER = logging.Formatter("%(asctime)-15s %(message)s")
-
-#https://stackoverflow.com/questions/22235426/python-multiprocessing-worker-queue
 
 
 ##### Settings #####
@@ -40,11 +38,6 @@ def get_current_server_lock_data():
             return
         return server_data
     
-
-
-
-
-
 ##### Server #####
 class IdLoggingStream:
     def __init__(self, id, send_method):
@@ -142,13 +135,13 @@ class Server:
         # Start Worker
         self.work_queue = Queue()
         self.done_queue = Queue()
-        processes = []
+        worker_threads = []
         for loaded_config in self.get_loaded_worker_configs():
-            p = Process(target=worker, args=(self.work_queue, self.done_queue, loaded_config))
+            p = Thread(target=worker, args=(self.work_queue, self.done_queue, loaded_config))
             p.start()
-            processes.append(p)
+            worker_threads.append(p)
             #work_queue.put('STOP')
-        # for p in processes:
+        # for p in worker_threads:
         #     p.join()    
         #     done_queue.put('STOP')
         # for status in iter(done_queue.get, 'STOP'): 

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -20,6 +20,32 @@ FORMATER = logging.Formatter("%(asctime)-15s %(message)s")
 
 #https://stackoverflow.com/questions/22235426/python-multiprocessing-worker-queue
 
+
+##### Settings #####
+WORKER_BASE_CONFIG = "config"
+CLONE_PARTIAL_CONFIGS = "clone_configs"
+
+LOCKFILE_NAME = "queue.lock"
+LOCKFILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), LOCKFILE_NAME)
+
+
+##### Shared #####
+def get_current_server_lock_data():
+    #FIXME: Not atomic
+    if os.path.exists(LOCKFILE_PATH):
+        with open(LOCKFILE_PATH, "r") as f:
+            server_data = json.load(f)
+        pid = server_data["pid"]
+        if not psutil.pid_exists(pid):
+            return
+        return server_data
+    
+
+
+
+
+
+##### Server #####
 class IdLoggingStream:
     def __init__(self, id, send_method):
         self.id = id
@@ -78,16 +104,6 @@ def run_task(task, config, logging_handler):
         logger = logging.getLogger(logger_name)
         logger.removeHandler(logging_handler)
 
-
-
-WORKER_BASE_CONFIG = "config"
-CLONE_PARTIAL_CONFIGS = "clone_configs"
-
-
-#FIXME: use global location
-LOCKFILE_NAME = "queue.lock"
-LOCKFILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), LOCKFILE_NAME)
-
 class FakeConfig:
     def __init__(self, input_config):
         for key in input_config.__dict__.keys():
@@ -96,14 +112,17 @@ class FakeConfig:
 
 class Server:
     def __init__(self):
-        self.get_listener_and_lock()
-        self.start_worker()
+        try:
+            self.get_listener_and_lock()
+            self.start_worker()
 
-        #Network: 
-        self.clients = [] 
-        Thread(target=self.handle_messages_from_workers).start()
-        #Thread(target=self.handle_incomming_connections).start()
-        self.handle_incomming_connections() # this will block
+            #Network: 
+            self.clients = [] 
+            Thread(target=self.handle_messages_from_workers).start()
+            #Thread(target=self.handle_incomming_connections).start()
+            self.handle_incomming_connections() # this will block
+        finally:
+            unlock_server()
 
     def get_loaded_worker_configs(self):
         base = importlib.import_module(WORKER_BASE_CONFIG)
@@ -145,9 +164,6 @@ class Server:
             }
             json.dump(server_data, f)
 
-    def unlock(self):
-        os.remove(LOCKFILE_PATH)
-
     def handle_messages(self, connection):
         for message in iter(connection.recv, "CLOSE"):
             self.work_queue.put(message)
@@ -167,16 +183,30 @@ class Server:
             Thread(target=self.handle_messages, args=(connection,)).start()
 
 
-def get_current_server_lock_data():
-    #FIXME: Not atomic
-    if os.path.exists(LOCKFILE_PATH):
-        with open(LOCKFILE_PATH, "r") as f:
-            server_data = json.load(f)
-        pid = server_data["pid"]
-        if not psutil.pid_exists(pid):
-            return
-        return server_data
-    
+def unlock_server():
+    os.remove(LOCKFILE_PATH)
+
+
+def start_server_safe():
+    server_data = get_current_server_lock_data()
+    if not server_data:
+        #Process(target=Server).start()
+        #Thread(target=Server).start()
+        Server() # blocks
+        time.sleep(0.1)
+    else:
+        LOG.warning("Server is already running. Did not start a new server.")
+    server_data = get_current_server_lock_data()
+    if server_data is None:
+        raise RuntimeError("Could not start roamerqueue server")
+    return server_data
+
+
+
+##### Client #####
+
+def connect_to_server(server_data):
+    return Client(server_data["address"])
 
 
 def get_files(target_path):
@@ -195,41 +225,10 @@ def get_files(target_path):
         LOG.exception("uncaught exception")
     return samples
 
-
-def start_server_safe():
+def unpack_samples(samples, headless, ident, block):
     server_data = get_current_server_lock_data()
     if not server_data:
-        #Process(target=Server).start()
-        Thread(target=Server).start()
-        time.sleep(0.1)
-        # Server()
-    server_data = get_current_server_lock_data()
-    if server_data is None:
-        raise RuntimeError("Could not start roamerqueue server")
-    return server_data
-
-def connect_to_server(server_data):
-    return Client(server_data["address"])
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='RoAMer')
-    parser.add_argument('Samples', metavar='Sample', type=str, help='Path to sample or folder of samples')
-    parser.add_argument('--no-headless', action='store_false', help='Start the Sandbox in headless mode', dest="headless")
-    parser.add_argument('--vm', action='store', help='This can be used to force a VM past the config-file', default="")
-    parser.add_argument('--snapshot', action='store', help='This can be used to force a snapshot past the config-file', default="")
-    parser.add_argument('--config', action='store', help="Which config shall be used?", default="config")
-    parser.add_argument('--ident', action="store", help="Configure an identifier for the output.", default="")
-    parser.add_argument('--allow-start-server', action="store_true")
-    parser.add_argument('--block', action="store_true")
-
-    args = parser.parse_args()
-    
-    if args.allow_start_server:
-        server_data = start_server_safe()
-    else:
-        server_data = get_current_server_lock_data()
-        if not server_data:
-            raise ValueError("Server not available")
+        raise ValueError("Server not available")
     connection = connect_to_server(server_data)
 
     assert connection
@@ -237,13 +236,13 @@ if __name__ == "__main__":
     task_base = {
         "sample": None,
         "config": None,
-        "headless": args.headless,
+        "headless": headless,
         "vm": "",
         "snapshot": "",
         "id": None,
-        "ident": args.ident,
+        "ident": ident,
     }
-    samples = get_files(args.Samples)
+    samples = get_files(samples)
     ids = []
     for sample in samples:
         task = dict(**task_base)
@@ -253,7 +252,7 @@ if __name__ == "__main__":
         ids.append(id)
         connection.send(task)
 
-    if args.block and ids:
+    if block and ids:
         for message in iter(connection.recv, "STOP"):
             if message["id"] in ids:
                 if "logging" in message and message["logging"]:
@@ -268,4 +267,23 @@ if __name__ == "__main__":
     time.sleep(0.1)        
 
 
+##### CLI #####
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='RoAMer')
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    send_parser = subparsers.add_parser("unpack")
+    send_parser.add_argument('Samples', metavar='Sample', type=str, help='Path to sample or folder of samples')
+    send_parser.add_argument('--no-headless', action='store_false', help='Start the Sandbox in headless mode', dest="headless")
+    send_parser.add_argument('--ident', action="store", help="Configure an identifier for the output.", default="")
+    send_parser.add_argument('--block', action="store_true")
+    server_parser = subparsers.add_parser("server")
+
+    args = parser.parse_args()
+
+    print(args.action)
+    if args.action == "server":
+        start_server_safe()
+    elif args.action == "unpack":
+        unpack_samples(args.Samples, args.headless, args.ident, args.block)
 

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -39,8 +39,9 @@ class ExtendedQueue(Queue):
             self.queue.remove(element)
             self.not_full.notify()
 
-    def __iter__(self):
-        return self.queue.__iter__()
+    def as_list(self):
+        with self.mutex:
+            return [*self.queue]
 
 
 ##### Shared #####
@@ -220,7 +221,7 @@ class WorkerHandler:
 
     def cancel_jobs(self, job_ids):
         remove_list = []
-        for job in self.work_queue:
+        for job in self.work_queue.as_list():
             if job and "id" in job and job["id"] in job_ids:
                 remove_list.append(job)
         for job_to_cancel in remove_list:
@@ -417,7 +418,7 @@ class Server:
                     {
                         "worker_configs": self.worker_handler.partial_configs,
                         "worker_tasks": self.worker_handler.current_worker_tasks,
-                        "queue": [*self.worker_handler.work_queue],
+                        "queue": self.worker_handler.work_queue.as_list(),
                     },
                     client_id
                 )

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -225,6 +225,12 @@ class WorkerHandler:
             process.join()
     
     def kill_workers(self):
+        # This allows feeders to shut down
+        for worker_queue in self.worker_queues.values():
+            try:
+                worker_queue.task_done()
+            except ValueError:
+                pass
         for process in self.workers.values():
             process.terminate()
 

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -7,9 +7,9 @@ import json
 import logging
 import os
 from threading import Thread
-from queue import Queue
 import time
 import traceback
+from multiprocessing import Process, Queue
 from multiprocessing.connection import Client, Listener
 
 from roamer.RoAMer import RoAMer
@@ -17,6 +17,8 @@ from roamer.RoAMer import RoAMer
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s %(message)s")
 FORMATER = logging.Formatter("%(asctime)-15s %(message)s")
+
+#https://stackoverflow.com/questions/22235426/python-multiprocessing-worker-queue
 
 
 ##### Settings #####
@@ -38,6 +40,11 @@ def get_current_server_lock_data():
             return
         return server_data
     
+
+
+
+
+
 ##### Server #####
 class IdLoggingStream:
     def __init__(self, id, send_method):
@@ -135,13 +142,13 @@ class Server:
         # Start Worker
         self.work_queue = Queue()
         self.done_queue = Queue()
-        worker_threads = []
+        processes = []
         for loaded_config in self.get_loaded_worker_configs():
-            p = Thread(target=worker, args=(self.work_queue, self.done_queue, loaded_config))
+            p = Process(target=worker, args=(self.work_queue, self.done_queue, loaded_config))
             p.start()
-            worker_threads.append(p)
+            processes.append(p)
             #work_queue.put('STOP')
-        # for p in worker_threads:
+        # for p in processes:
         #     p.join()    
         #     done_queue.put('STOP')
         # for status in iter(done_queue.get, 'STOP'): 

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -642,6 +642,12 @@ def unpack_samples(samples, config, headless, ident, output_folder, block):
             monitor_ids(connection, ids)
     
 
+def watch_status(connection, refresh_time):
+    while True:
+        os.system('cls' if os.name == 'nt' else 'clear')
+        show_status(connection)
+        time.sleep(refresh_time)
+
 def show_status(connection):
     connection.send(
         {
@@ -650,7 +656,8 @@ def show_status(connection):
     )
     message = None
     for message in iter_connection(connection):
-        break
+        if message is not None and "worker_tasks" in message:
+            break
     if message is not None:
         worker_configs = message["worker_configs"]
         worker_tasks = message["worker_tasks"]
@@ -701,6 +708,8 @@ if __name__ == "__main__":
     shutdown_flag_group.add_argument('--force', action="store_true")
     shutdown_flag_group.add_argument('--finish-queue', action="store_true")
     status_parser = subparsers.add_parser("status")
+    status_parser.add_argument('--watch', action="store_true")
+    status_parser.add_argument('--watch-time', type=float, default=1)
 
     args = parser.parse_args()
 
@@ -722,7 +731,10 @@ if __name__ == "__main__":
             shutdown_server(connection, force=args.force, finish_queue=args.finish_queue)
     elif args.action == "status":
         with connect_to_server() as connection: # might throw
-            show_status(connection)
+            if args.watch:
+                watch_status(connection, args.watch_time)
+            else:
+                show_status(connection)
             
 
 

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -276,7 +276,10 @@ class ClientHandler:
             self.clients[client_id] = connection
             message_backlog = []
             if connection.poll(0.1):
+                try:
                 first_message = connection.recv()
+                except EOFError:
+                    continue
                 if first_message == "STOPLISTENER":
                     connection.close()
                     break

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -1,0 +1,249 @@
+import argparse
+import uuid
+import psutil
+import importlib
+import json
+import logging
+import os
+from threading import Thread
+import time
+import traceback
+from multiprocessing import Process, Queue
+from multiprocessing.connection import Client, Listener
+
+from roamer.RoAMer import RoAMer
+
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s %(message)s")
+FORMATER = logging.Formatter("%(asctime)-15s %(message)s")
+
+#https://stackoverflow.com/questions/22235426/python-multiprocessing-worker-queue
+
+class IdLoggingStream:
+    def __init__(self, id, send_method):
+        self.id = id
+        self.send_method = send_method
+
+    def write(self, record):
+        self.send_method(
+            {
+                "id": self.id,
+                "logging": True,
+                "record": record,
+            }
+        )
+
+    def close(self):
+        pass
+
+
+def worker(work_queue, done_queue, config):
+    for task in iter(work_queue.get, 'STOP'):
+        try:
+            print(task)
+            logging_handler = logging.StreamHandler(IdLoggingStream(task["id"], done_queue.put))
+            logging_handler.terminator = ""
+            logging_handler.setFormatter(FORMATER)
+            run_task(task, config, logging_handler)
+            done_queue.put(
+                {
+                    "state": "finished",
+                    "id": task["id"],
+                }
+            )
+        except Exception as e:        
+            done_queue.put(
+                {
+                    "state": "failed",
+                    "id": task["id"],
+                    "error": traceback.format_exc(),
+                }
+            )
+
+
+def run_task(task, config, logging_handler):
+
+    #loggers = ["roamer.VmController", "roamer", "roamer.RoAMer", "roamer.CuckooVirtualBox"]
+    loggers = ["roamer"]
+    for logger_name in loggers:
+        logger = logging.getLogger(logger_name)
+        logger.addHandler(logging_handler)
+
+    roamer = RoAMer(config, task["headless"], task["vm"], task["snapshot"], task["ident"])
+    roamer.run(task["sample"])
+
+    for logger_name in loggers:
+        logger = logging.getLogger(logger_name)
+        logger.removeHandler(logging_handler)
+
+
+
+worker_configs = ["config", "config_clone1"]
+
+
+
+
+#FIXME: use global location
+LOCKFILE_NAME = "queue.lock"
+LOCKFILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), LOCKFILE_NAME)
+
+class Server:
+    def __init__(self):
+        self.get_listener_and_lock()
+        self.clients = [] 
+        self.start_worker()
+        Thread(target=self.handle_messages_from_workers).start()
+        #Thread(target=self.handle_incomming_connections).start()
+        self.handle_incomming_connections() # this will block
+
+    def start_worker(self):
+        # Start Worker
+        self.work_queue = Queue()
+        self.done_queue = Queue()
+        processes = []
+        for config in worker_configs:
+            loaded_config = importlib.import_module(config)
+            p = Process(target=worker, args=(self.work_queue, self.done_queue, loaded_config))
+            p.start()
+            processes.append(p)
+            #work_queue.put('STOP')
+        # for p in processes:
+        #     p.join()    
+        #     done_queue.put('STOP')
+        # for status in iter(done_queue.get, 'STOP'): 
+    
+
+    def get_listener_and_lock(self):
+        with open(LOCKFILE_PATH, "w") as f:
+            self.listener = Listener() 
+            print(self.listener.address)
+            server_data = {
+                "address": self.listener.address,
+                "pid": os.getpid(),
+            }
+            json.dump(server_data, f)
+
+    def unlock(self):
+        os.remove(LOCKFILE_PATH)
+
+    def handle_messages(self, connection):
+        for message in iter(connection.recv, "CLOSE"):
+            self.work_queue.put(message)
+    
+    def handle_messages_from_workers(self):
+        for message in iter(self.done_queue.get, "STOP"):
+            for client in self.clients:
+                try:
+                    client.send(message)
+                except Exception as e:
+                    self.clients.remove(client)
+
+    def handle_incomming_connections(self):
+        while True:
+            connection = self.listener.accept()
+            self.clients.append(connection)
+            Thread(target=self.handle_messages, args=(connection,)).start()
+
+
+def get_current_server_lock_data():
+    #FIXME: Not atomic
+    if os.path.exists(LOCKFILE_PATH):
+        with open(LOCKFILE_PATH, "r") as f:
+            server_data = json.load(f)
+        pid = server_data["pid"]
+        if not psutil.pid_exists(pid):
+            return
+        return server_data
+    
+
+
+def get_files(target_path):
+    samples = []
+    try:
+        if os.path.isdir(target_path):
+            for filename in os.listdir(target_path):
+                sample = os.path.join(target_path, filename)
+                if os.path.isfile(sample):
+                    samples.append(os.path.abspath(sample))
+        elif os.path.isfile(target_path):
+            samples.append(os.path.abspath(target_path))
+        else:
+            LOG.error("Target was neither file nor directory, aborting.")
+    except Exception:
+        LOG.exception("uncaught exception")
+    return samples
+
+
+def start_server_safe():
+    server_data = get_current_server_lock_data()
+    if not server_data:
+        #Process(target=Server).start()
+        Thread(target=Server).start()
+        time.sleep(0.1)
+        # Server()
+    server_data = get_current_server_lock_data()
+    if server_data is None:
+        raise RuntimeError("Could not start roamerqueue server")
+    return server_data
+
+def connect_to_server(server_data):
+    return Client(server_data["address"])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='RoAMer')
+    parser.add_argument('Samples', metavar='Sample', type=str, help='Path to sample or folder of samples')
+    parser.add_argument('--no-headless', action='store_false', help='Start the Sandbox in headless mode', dest="headless")
+    parser.add_argument('--vm', action='store', help='This can be used to force a VM past the config-file', default="")
+    parser.add_argument('--snapshot', action='store', help='This can be used to force a snapshot past the config-file', default="")
+    parser.add_argument('--config', action='store', help="Which config shall be used?", default="config")
+    parser.add_argument('--ident', action="store", help="Configure an identifier for the output.", default="")
+    parser.add_argument('--allow-start-server', action="store_true")
+    parser.add_argument('--block', action="store_true")
+
+    args = parser.parse_args()
+    
+    if args.allow_start_server:
+        server_data = start_server_safe()
+    else:
+        server_data = get_current_server_lock_data()
+        if not server_data:
+            raise ValueError("Server not available")
+    connection = connect_to_server(server_data)
+
+    assert connection
+
+    task_base = {
+        "sample": None,
+        "config": None,
+        "headless": args.headless,
+        "vm": "",
+        "snapshot": "",
+        "id": None,
+        "ident": args.ident,
+    }
+    samples = get_files(args.Samples)
+    ids = []
+    for sample in samples:
+        task = dict(**task_base)
+        task["sample"] = sample
+        id = uuid.uuid4()
+        task["id"] = id
+        ids.append(id)
+        connection.send(task)
+
+    if args.block and ids:
+        for message in iter(connection.recv, "STOP"):
+            if message["id"] in ids:
+                if "logging" in message and message["logging"]:
+                    print(message["record"], flush=True)
+                else:
+                    print(message, flush=True)
+                    ids.remove(message["id"])
+            if not ids:
+                break
+    
+    connection.send("CLOSE")
+    time.sleep(0.1)        
+
+
+

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -1,5 +1,6 @@
 import argparse
 from copy import deepcopy
+from queue import Empty
 import uuid
 import psutil
 import importlib
@@ -179,6 +180,12 @@ class WorkerHandler:
     def enqueue_job(self, job):
         self.work_queue.put(job)
 
+    def clear_queue(self):
+        try:
+            while True:
+                self.work_queue.get_nowait()
+        except Empty:
+            pass 
 
     def run_handle_messages(self):
         for message in iter(self.done_queue.get, "STOP"):

--- a/template.clone_configs.py
+++ b/template.clone_configs.py
@@ -1,0 +1,24 @@
+# For each additional VM you want to use for parallel unpacking with the queue, 
+# add a small partial config file below.
+PARTIAL_CLONE_CONFIGS = [
+    #### Example 1 ####
+    # This example adds one additional VM instances:
+    # {
+    #     "host_port": 10001,
+    #     "guest_ip": "192.168.56.102",
+    #     "VM_CONTROLLER": "VboxManageController",
+    #     "VM_NAME": "vm_name_Clone_1",
+    #     "SNAPSHOT_NAME": "snapshot_name",
+    # },
+
+    #### Example 2 ####
+    # This example adds three additional VM instances automatically:
+    # {
+    #     "host_port": 10000+i,
+    #     "guest_ip": f"192.168.56.{101+i}",
+    #     "VM_CONTROLLER": "VboxManageController",
+    #     "VM_NAME": f"vm_name_Clone_{i}",
+    #     "SNAPSHOT_NAME": "snapshot_name",
+    # } for i in range(1,4)
+
+]


### PR DESCRIPTION
This PR adds a queue for RoAMer.
It allows:
- queueing jobs and distributing them among multiple RoAMer VMs running simultaneously
- monitoring the output of RoAMer
- clearing the queue
- cancelling individual queued jobs
- killing already running jobs
- displaying the state of the workers and the queue