### PR TITLE
Queue improvements

### DIFF
--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -582,8 +582,9 @@ def monitor_ids(connection, ids):
     except KeyboardInterrupt:
         answer = None
         print()
-        while answer not in ["d", "c", "m", "k"]:
-            answer = input("""What do you want to do (d/c/m/k):
+        while answer not in ["r", "d", "c", "m", "k"]:
+            answer = input("""What do you want to do (a/d/c/m/k):
+r) keep running
 d) detach, i.e. stop monitoring
 c) cancel your unstarted queued jobs and stop monitoring
 m) cancel your unstarted queued jobs and keep monitoring running jobs
@@ -594,7 +595,7 @@ k) cancel and/or kill all of your jobs
             cancel_ids(connection, ids, allow_kill=False)
         if answer == "k":
             cancel_ids(connection, ids, allow_kill=True)
-        if answer == "m":
+        if answer in ["m", "r"]:
             monitor_ids(connection, ids)
 
 

--- a/roamerqueue.py
+++ b/roamerqueue.py
@@ -1,6 +1,7 @@
 import argparse
 from copy import deepcopy
 import io
+from itertools import chain
 from queue import Empty
 import sys
 import uuid
@@ -641,7 +642,7 @@ def unpack_samples(samples, config, headless, ident, output_folder, block, prior
             "ident": ident,
             "priority": priority,
         }
-        samples = get_files(samples)
+        samples = chain(*[get_files(entry) for entry in samples])
         ids = []
         for sample in samples:
             task = dict(**task_base)
@@ -706,7 +707,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='RoAMer')
     subparsers = parser.add_subparsers(dest="action", required=True)
     send_parser = subparsers.add_parser("unpack")
-    send_parser.add_argument('Samples', metavar='Sample', type=str, help='Path to sample or folder of samples')
+    send_parser.add_argument('Samples', metavar='Sample', nargs="+", type=str, help='Path to sample or folder of samples')
     send_parser.add_argument('--config', action='store', help="Which config shall be used?", default=WORKER_BASE_CONFIG)
     send_parser.add_argument('--no-headless', action='store_false', help='Start the Sandbox in headless mode', dest="headless")
     send_parser.add_argument('--ident', action="store", help="Configure an identifier for the output.", default="")


### PR DESCRIPTION
Some improvements to the RoAMer-queue:

- use the `--first` flag to put samples at the front of the queue
- more than one sample/folder can be given to the CLI at once
- it is now possible to leave the monitoring of samples running after an Ctrl-C interrupt.
- the new `--continue` flag can be used to instruct the queue to ignore samples which already have a `_dump` folder. This option also works correctly in combination with `--ident` and `--output`